### PR TITLE
Bump color-string to 1.9.0

### DIFF
--- a/colour-proximity.js
+++ b/colour-proximity.js
@@ -6,8 +6,8 @@ module.exports = {
 };
 
 function proximity(s1, s2){
-	c1 = rgb2lab(cs.getRgb(s1));
-	c2 = rgb2lab(cs.getRgb(s2));
+	c1 = rgb2lab(cs.get.rgb(s1));
+	c2 = rgb2lab(cs.get.rgb(s2));
 	return Math.sqrt(Math.pow(c1[0]-c2[0],2) + Math.pow(c1[1]-c2[1],2) + Math.pow(c1[2]-c2[2],2));
 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Lab"
   ],
   "dependencies": {
-    "color-string": "~0.1.2"
+    "color-string": "~1.9.0"
   },
   "license": "GPLv3"
 }


### PR DESCRIPTION
Fix https://github.com/advisories/GHSA-257v-vj4p-3w2h

I tested this by checking out and running https://github.com/juliuste/closest-css-color/blob/main/test.js. All tests passed.